### PR TITLE
 m_rank should be a 1-indexed array

### DIFF
--- a/skchem/metrics.py
+++ b/skchem/metrics.py
@@ -45,7 +45,7 @@ def bedroc_score(y_true, y_pred, decreasing=True, alpha=20.0):
     else:
         order = np.argsort(y_pred)
 
-    m_rank = (y_true[order] == 1).nonzero()[0]
+    m_rank = (y_true[order] == 1).nonzero()[0] + 1
 
     s = np.sum(np.exp(-alpha * m_rank / big_n))
 


### PR DESCRIPTION
I think m_rank, which represents r_i  in the Truchon and Bayly paper, should be a 1-indexed array. Otherwise, the BEDROC value will reach values above 1. Changing to a 1-indexed array, I managed to get similar results to the CalcBEDROC() function from the rdkit.ML.Scoring.Scoring module.